### PR TITLE
chore(KFLUXVNGD-491): Add envtest support to coverage workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -38,6 +38,16 @@ jobs:
           sudo apt-get install -y jq
           pip install yq
 
+      - name: Install and setup envtest
+        run: |
+          # Install setup-envtest
+          go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+
+          # Setup envtest binaries and get the path
+          ENVTEST_ASSETS_DIR=$(setup-envtest use -p path)
+          echo "KUBEBUILDER_ASSETS=$ENVTEST_ASSETS_DIR" >> $GITHUB_ENV
+          echo "Envtest assets installed at: $ENVTEST_ASSETS_DIR"
+
       - name: Prepare workspace
         run: mkdir workspace
 

--- a/repos.yaml
+++ b/repos.yaml
@@ -29,7 +29,6 @@ repositories:
      - hack/
      - proto/
      - test/
-     - internal/controller
      - /fake(/|$)
    exclude_files:
      - zz_generated.deepcopy.go
@@ -42,7 +41,6 @@ repositories:
      - hack/
      - proto/
      - test/
-     - internal/controller/
      - /fake(/|$)
    exclude_files:
      - zz_generated.deepcopy.go


### PR DESCRIPTION
Fixes test failures for repos that require a local Kubernetes API server for controller/webhook testing.

Jira-Url: https://issues.redhat.com/browse/KFLUXVNGD-491