### PR TITLE
feat(KFLUXVNGD-494): Add ownership detection package

### DIFF
--- a/internal/ownership/detector.go
+++ b/internal/ownership/detector.go
@@ -1,0 +1,214 @@
+package ownership
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+
+	"github.com/google/go-github/v66/github"
+)
+
+// codeownersPaths defines the list of paths to check for CODEOWNERS files
+// Ordered by priority - checked in sequence until one is found
+var codeownersPaths = []string{
+	".github/CODEOWNERS",
+	"CODEOWNERS",
+	"docs/CODEOWNERS",
+}
+
+// GetCodeownersPaths returns a copy of the CODEOWNERS file paths
+// This allows inspection of the paths without allowing external modification
+func GetCodeownersPaths() []string {
+	paths := make([]string, len(codeownersPaths))
+	copy(paths, codeownersPaths)
+	return paths
+}
+
+// Detector detects repository ownership using multiple strategies
+type Detector struct {
+	client       *github.Client
+	defaultOwner string
+}
+
+// NewDetector creates a new ownership detector
+// defaultOwner specifies the fallback owner when no owners can be detected through other means
+// If empty, defaults to "@konflux-ci/Vanguard"
+func NewDetector(client *github.Client, defaultOwner string) *Detector {
+	if defaultOwner == "" {
+		defaultOwner = "@konflux-ci/Vanguard"
+	}
+	return &Detector{
+		client:       client,
+		defaultOwner: defaultOwner,
+	}
+}
+
+// DetectOwners detects repository owners using a fallback chain:
+// 1. CODEOWNERS file (most authoritative)
+// 2. GitHub repository teams with admin/maintain permissions
+// 3. Individual collaborators with admin/maintain permissions
+// 4. Configured default owner (@konflux-ci/Vanguard if empty was provided to constructor)
+func (d *Detector) DetectOwners(ctx context.Context, org, repo string) ([]string, error) {
+	// Try CODEOWNERS file first
+	owners, err := d.detectFromCodeowners(ctx, org, repo)
+	if err == nil && len(owners) > 0 {
+		return owners, nil
+	}
+
+	// Fallback to repository teams
+	owners, err = d.detectFromTeams(ctx, org, repo)
+	if err == nil && len(owners) > 0 {
+		return owners, nil
+	}
+
+	// Fallback to individual collaborators
+	owners, err = d.detectFromCollaborators(ctx, org, repo)
+	if err == nil && len(owners) > 0 {
+		return owners, nil
+	}
+
+	// Final fallback to configured default owner
+	return []string{d.defaultOwner}, nil
+}
+
+// detectFromCodeowners attempts to find owners in CODEOWNERS file
+// Checks multiple standard locations in priority order
+func (d *Detector) detectFromCodeowners(ctx context.Context, org, repo string) ([]string, error) {
+	var lastErr error
+
+	// Try each CODEOWNERS path in order
+	for _, path := range codeownersPaths {
+		content, err := d.fetchFile(ctx, org, repo, path)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+
+		// Successfully fetched file, extract owners
+		owners := extractOwnersFromCodeowners(content)
+		if len(owners) > 0 {
+			return owners, nil
+		}
+
+		// File exists but has no valid owners
+		lastErr = fmt.Errorf("no valid owners found in %s", path)
+	}
+
+	// No CODEOWNERS file found or none had valid owners
+	if lastErr != nil {
+		return nil, fmt.Errorf("failed to detect owners from CODEOWNERS: %w", lastErr)
+	}
+
+	return nil, fmt.Errorf("no CODEOWNERS files found")
+}
+
+// detectFromTeams queries GitHub API for repository teams
+func (d *Detector) detectFromTeams(ctx context.Context, org, repo string) ([]string, error) {
+	if d.client == nil {
+		return nil, fmt.Errorf("GitHub client not configured")
+	}
+
+	teams, _, err := d.client.Repositories.ListTeams(ctx, org, repo, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list teams for %s/%s: %w", org, repo, err)
+	}
+
+	var owners []string
+	for _, team := range teams {
+		// Only include teams with admin or maintain permissions
+		perm := team.GetPermission()
+		if perm == "admin" || perm == "maintain" {
+			owners = append(owners, fmt.Sprintf("@%s/%s", org, team.GetSlug()))
+			if len(owners) >= 3 {
+				break
+			}
+		}
+	}
+
+	if len(owners) == 0 {
+		return nil, fmt.Errorf("no teams with admin/maintain permissions found")
+	}
+
+	return owners, nil
+}
+
+// detectFromCollaborators queries GitHub API for individual repository collaborators
+func (d *Detector) detectFromCollaborators(ctx context.Context, org, repo string) ([]string, error) {
+	if d.client == nil {
+		return nil, fmt.Errorf("GitHub client not configured")
+	}
+
+	opts := &github.ListCollaboratorsOptions{
+		Affiliation: "direct",
+		ListOptions: github.ListOptions{PerPage: 100},
+	}
+
+	collaborators, _, err := d.client.Repositories.ListCollaborators(ctx, org, repo, opts)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list collaborators for %s/%s: %w", org, repo, err)
+	}
+
+	var owners []string
+	for _, collab := range collaborators {
+		// Only include collaborators with admin or maintain permissions
+		perms := collab.GetPermissions()
+		if perms["admin"] || perms["maintain"] {
+			owners = append(owners, "@"+collab.GetLogin())
+			if len(owners) >= 5 {
+				break
+			}
+		}
+	}
+
+	if len(owners) == 0 {
+		return nil, fmt.Errorf("no collaborators with admin/maintain permissions found")
+	}
+
+	return owners, nil
+}
+
+// fetchFile fetches a file from GitHub repository using the GitHub API
+func (d *Detector) fetchFile(ctx context.Context, org, repo, path string) (string, error) {
+	if d.client == nil {
+		return "", fmt.Errorf("GitHub client not configured")
+	}
+
+	// GetContents automatically uses the default branch
+	fileContent, _, _, err := d.client.Repositories.GetContents(ctx, org, repo, path, nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to fetch %s: %w", path, err)
+	}
+
+	if fileContent == nil {
+		return "", fmt.Errorf("file %s exists but content is nil", path)
+	}
+
+	content, err := fileContent.GetContent()
+	if err != nil {
+		return "", fmt.Errorf("failed to decode content from %s: %w", path, err)
+	}
+
+	return content, nil
+}
+
+// extractOwnersFromCodeowners parses CODEOWNERS content and extracts owner references
+func extractOwnersFromCodeowners(content string) []string {
+	ownerPattern := regexp.MustCompile(`@[a-zA-Z0-9_-]+(/[a-zA-Z0-9_-]+)?`)
+
+	matches := ownerPattern.FindAllString(content, -1)
+
+	// Deduplicate and limit to 5
+	seen := make(map[string]bool)
+	var owners []string
+	for _, match := range matches {
+		if !seen[match] {
+			seen[match] = true
+			owners = append(owners, match)
+			if len(owners) >= 5 {
+				break
+			}
+		}
+	}
+
+	return owners
+}

--- a/internal/ownership/detector_test.go
+++ b/internal/ownership/detector_test.go
@@ -1,0 +1,317 @@
+package ownership_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/google/go-github/v66/github"
+
+	"github.com/konflux-ci/coverage-dashboard/internal/ownership"
+)
+
+// Common test data
+const (
+	adminMaintainCollaboratorsJSON = `[
+		{
+			"login": "admin-user",
+			"permissions": {
+				"admin": true,
+				"maintain": false
+			}
+		},
+		{
+			"login": "maintain-user",
+			"permissions": {
+				"admin": false,
+				"maintain": true
+			}
+		}
+	]`
+	
+	noPermCollaboratorsJSON = `[
+		{
+			"login": "read-user",
+			"permissions": {
+				"admin": false,
+				"maintain": false
+			}
+		}
+	]`
+)
+
+var _ = Describe("Detector", func() {
+	var (
+		ctx      context.Context
+		detector *ownership.Detector
+		client   *github.Client
+		server   *httptest.Server
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+	})
+
+	AfterEach(func() {
+		if server != nil {
+			server.Close()
+		}
+	})
+
+	Describe("NewDetector", func() {
+		It("should create a new detector with provided client", func() {
+			d := ownership.NewDetector(github.NewClient(nil), "")
+			Expect(d).NotTo(BeNil())
+		})
+
+		It("should create a detector with nil client", func() {
+			d := ownership.NewDetector(nil, "")
+			Expect(d).NotTo(BeNil())
+		})
+
+		It("should use custom default owner when provided", func() {
+			d := ownership.NewDetector(nil, "@custom-org/custom-team")
+			Expect(d).NotTo(BeNil())
+			owners, err := d.DetectOwners(ctx, "test-org", "test-repo")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(owners).To(Equal([]string{"@custom-org/custom-team"}))
+		})
+	})
+
+	Describe("DetectOwners", func() {
+		Context("when no GitHub client is configured", func() {
+			BeforeEach(func() {
+				detector = ownership.NewDetector(nil, "")
+			})
+
+			It("should return exactly only the Vanguard owner as fallback", func() {
+				owners, err := detector.DetectOwners(ctx, "org", "repo")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(owners).To(HaveLen(1))
+				Expect(owners).To(Equal([]string{"@konflux-ci/Vanguard"}))
+			})
+		})
+
+		Context("CODEOWNERS file parsing", func() {			
+			It("should check multiple CODEOWNERS paths in order", func() {
+				// Verify that the paths list exists and contains expected paths
+				Expect(ownership.GetCodeownersPaths()).To(ContainElement(".github/CODEOWNERS"))																																										
+				Expect(ownership.GetCodeownersPaths()).To(ContainElement("CODEOWNERS"))
+			})
+		})
+
+		Context("with GitHub client configured", func() {
+			BeforeEach(func() {
+				server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					switch r.URL.Path {
+					case "/repos/org/repo/teams":
+						// Mock teams response
+						response := `[
+							{
+								"slug": "admin-team",
+								"permission": "admin"
+							},
+							{
+								"slug": "maintain-team", 
+								"permission": "maintain"
+							},
+							{
+								"slug": "read-team",
+								"permission": "read"
+							}
+						]`
+						w.Header().Set("Content-Type", "application/json")
+						fmt.Fprint(w, response)
+					case "/repos/org/repo/collaborators":
+						w.Header().Set("Content-Type", "application/json")
+						fmt.Fprint(w, adminMaintainCollaboratorsJSON)
+					case "/repos/no-teams/repo/teams":
+						// Mock empty teams response
+						w.Header().Set("Content-Type", "application/json")
+						fmt.Fprint(w, "[]")
+					case "/repos/no-teams/repo/collaborators":
+						w.Header().Set("Content-Type", "application/json")
+						fmt.Fprint(w, adminMaintainCollaboratorsJSON)
+					case "/repos/no-perms/repo/teams":
+						// Mock teams without admin/maintain permissions
+						response := `[
+							{
+								"slug": "read-team",
+								"permission": "read"
+							}
+						]`
+						w.Header().Set("Content-Type", "application/json")
+						fmt.Fprint(w, response)
+					case "/repos/no-perms/repo/collaborators":
+						w.Header().Set("Content-Type", "application/json")
+						fmt.Fprint(w, noPermCollaboratorsJSON)
+					default:
+						http.NotFound(w, r)
+					}
+				}))
+
+				// Configure client to use test server
+				baseURL, _ := url.Parse(server.URL + "/")
+				client = github.NewClient(nil)
+				client.BaseURL = baseURL
+				detector = ownership.NewDetector(client, "")
+			})
+
+			It("should detect owners from teams when available", func() {
+				owners, err := detector.DetectOwners(ctx, "org", "repo")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(owners).NotTo(BeEmpty())
+				
+				// Should contain admin and maintain teams
+				Expect(owners).To(ContainElement("@org/admin-team"))
+				Expect(owners).To(ContainElement("@org/maintain-team"))
+			})
+
+			It("should fallback to collaborators when no teams available", func() {
+				owners, err := detector.DetectOwners(ctx, "no-teams", "repo")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(owners).NotTo(BeEmpty())
+				
+				// Should contain admin and maintain users
+				Expect(owners).To(ContainElement("@admin-user"))
+				Expect(owners).To(ContainElement("@maintain-user"))
+			})
+
+			It("should fallback to default when no teams or collaborators have permissions", func() {
+				owners, err := detector.DetectOwners(ctx, "no-perms", "repo")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(owners).To(Equal([]string{"@konflux-ci/Vanguard"}))
+			})
+		})
+
+		Context("when GitHub API returns errors", func() {
+			BeforeEach(func() {
+				server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					// Return 500 error for all requests
+					w.WriteHeader(http.StatusInternalServerError)
+					fmt.Fprint(w, "Internal Server Error")
+				}))
+
+				baseURL, _ := url.Parse(server.URL + "/")
+				client = github.NewClient(nil)
+				client.BaseURL = baseURL
+				detector = ownership.NewDetector(client, "")
+			})
+
+			It("should fallback to Vanguard when API calls fail", func() {
+				owners, err := detector.DetectOwners(ctx, "org", "repo")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(owners).To(Equal([]string{"@konflux-ci/Vanguard"}))
+			})
+		})
+
+	})
+
+
+	Describe("Integration scenarios", func() {
+		Context("with realistic GitHub responses", func() {
+			BeforeEach(func() {
+				server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					switch r.URL.Path {
+					case "/repos/konflux-ci/test-repo/teams":
+						// Realistic response with multiple teams and permissions
+						response := `[
+							{
+								"slug": "admins",
+								"permission": "admin"
+							},
+							{
+								"slug": "maintainers",
+								"permission": "maintain"
+							},
+							{
+								"slug": "contributors",
+								"permission": "write"
+							},
+							{
+								"slug": "readers",
+								"permission": "read"
+							}
+						]`
+						w.Header().Set("Content-Type", "application/json")
+						fmt.Fprint(w, response)
+					case "/repos/many-teams/repo/teams":
+						// Test with many teams to verify limit
+						response := `[
+							{"slug": "team1", "permission": "admin"},
+							{"slug": "team2", "permission": "admin"},
+							{"slug": "team3", "permission": "admin"},
+							{"slug": "team4", "permission": "admin"},
+							{"slug": "team5", "permission": "admin"}
+						]`
+						w.Header().Set("Content-Type", "application/json")
+						fmt.Fprint(w, response)
+					case "/repos/many-collaborators/repo/teams":
+						// No teams, will fallback to collaborators
+						w.Header().Set("Content-Type", "application/json")
+						fmt.Fprint(w, "[]")
+					case "/repos/many-collaborators/repo/collaborators":
+						// Test with many collaborators to verify limit
+						response := `[
+							{"login": "user1", "permissions": {"admin": true}},
+							{"login": "user2", "permissions": {"admin": true}},
+							{"login": "user3", "permissions": {"admin": true}},
+							{"login": "user4", "permissions": {"admin": true}},
+							{"login": "user5", "permissions": {"admin": true}},
+							{"login": "user6", "permissions": {"admin": true}},
+							{"login": "user7", "permissions": {"admin": true}}
+						]`
+						w.Header().Set("Content-Type", "application/json")
+						fmt.Fprint(w, response)
+					default:
+						http.NotFound(w, r)
+					}
+				}))
+
+				baseURL, _ := url.Parse(server.URL + "/")
+				client = github.NewClient(nil)
+				client.BaseURL = baseURL
+				detector = ownership.NewDetector(client, "")
+			})
+
+			It("should only include teams with admin/maintain permissions", func() {
+				owners, err := detector.DetectOwners(ctx, "konflux-ci", "test-repo")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(owners).NotTo(BeEmpty())
+				
+				// Should include admin and maintain teams but not write/read
+				Expect(owners).To(ContainElement("@konflux-ci/admins"))
+				Expect(owners).To(ContainElement("@konflux-ci/maintainers"))
+				Expect(owners).NotTo(ContainElement("@konflux-ci/contributors"))
+				Expect(owners).NotTo(ContainElement("@konflux-ci/readers"))
+			})
+
+			It("should limit number of teams returned to 3", func() {
+				owners, err := detector.DetectOwners(ctx, "many-teams", "repo")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(len(owners)).To(Equal(3))
+				
+				// Should contain team references with proper formatting
+				for _, owner := range owners {
+					Expect(owner).To(MatchRegexp(`^@many-teams/team\d+$`))
+				}
+			})
+
+			It("should limit number of collaborators returned to 5", func() {
+				owners, err := detector.DetectOwners(ctx, "many-collaborators", "repo")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(len(owners)).To(Equal(5))
+				
+				// Should contain user references with proper formatting
+				for _, owner := range owners {
+					Expect(owner).To(MatchRegexp(`^@user\d+$`))
+				}
+			})
+		})
+
+	})
+})

--- a/internal/ownership/ownership_suite_test.go
+++ b/internal/ownership/ownership_suite_test.go
@@ -1,0 +1,13 @@
+package ownership_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestOwnership(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Ownership Suite")
+}


### PR DESCRIPTION
### **User description**
This package detects repository ownership using a fallback chain:
1. CODEOWNERS file in the repository (most authoritative)
2. GitHub teams with admin/maintain permissions
3. Individual collaborators with admin/maintain permissions
4. Vangaurd team if above fails

Jira-Url: https://issues.redhat.com/browse/KFLUXVNGD-494
Signed-off-by: Homaja Marisetty <hmariset@redhat.com>
Assisted-By: Claude Code


___

### **PR Type**
Enhancement


___

### **Description**
- Adds ownership detection package with fallback chain strategy

- Detects owners from CODEOWNERS file, GitHub teams, collaborators

- Implements safe fallback to @konflux-ci/Vanguard team

- Includes comprehensive test coverage with mocked GitHub API


___

### Diagram Walkthrough


```mermaid
flowchart LR
  DetectOwners["DetectOwners<br/>method"]
  CODEOWNERS["CODEOWNERS<br/>file"]
  Teams["GitHub<br/>teams"]
  Collaborators["Individual<br/>collaborators"]
  Vanguard["@konflux-ci/<br/>Vanguard"]
  
  DetectOwners -->|"try first"| CODEOWNERS
  CODEOWNERS -->|"if empty"| Teams
  Teams -->|"if empty"| Collaborators
  Collaborators -->|"if empty"| Vanguard
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>detector.go</strong><dd><code>Core ownership detection implementation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/ownership/detector.go

<ul><li>Implements <code>Detector</code> struct with GitHub client for ownership detection<br> <li> Provides <code>DetectOwners</code> method implementing fallback chain strategy<br> <li> Includes methods to detect owners from CODEOWNERS file, teams, and <br>collaborators<br> <li> Fetches files from GitHub raw content and parses owner references <br>using regex</ul>


</details>


  </td>
  <td><a href="https://github.com/konflux-ci/coverage-dashboard/pull/11/files#diff-c281ad606f7bbed326345da0f165dd2c408e86afba3510ad3ef1f79a69e239a9">+186/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>detector_test.go</strong><dd><code>Comprehensive test coverage for detector</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/ownership/detector_test.go

<ul><li>Comprehensive test suite using Ginkgo/Gomega framework<br> <li> Tests detector initialization and nil client handling<br> <li> Mocks GitHub API responses for teams and collaborators<br> <li> Validates fallback chain behavior and limit enforcement (3 teams, 5 <br>collaborators)<br> <li> Tests error scenarios and integration with realistic GitHub responses</ul>


</details>


  </td>
  <td><a href="https://github.com/konflux-ci/coverage-dashboard/pull/11/files#diff-7075daf7f911ab67f31b3a644f57fea932a5195c6389ad63143013e126a6991f">+372/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ownership_suite_test.go</strong><dd><code>Test suite initialization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/ownership/ownership_suite_test.go

<ul><li>Initializes Ginkgo test suite for ownership package<br> <li> Registers failure handler and runs ownership tests</ul>


</details>


  </td>
  <td><a href="https://github.com/konflux-ci/coverage-dashboard/pull/11/files#diff-e63e0eaaa4b860b6466e84f0fb36b203b62ccef72591192a3f397e709201c3f2">+13/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

