### PR TITLE
test: Convert pr package tests to Gomega

### DIFF
--- a/internal/pr/creator_test.go
+++ b/internal/pr/creator_test.go
@@ -1,98 +1,48 @@
 package pr
 
 import (
-	"testing"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
-func TestExtractRepoName(t *testing.T) {
-	tests := []struct {
-		name     string
-		fullName string
-		expected string
-	}{
-		{
-			name:     "org/repo format",
-			fullName: "konflux-ci/caching",
-			expected: "caching",
-		},
-		{
-			name:     "no org prefix",
-			fullName: "standalone-repo",
-			expected: "standalone-repo",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := extractRepoName(tt.fullName)
-			if result != tt.expected {
-				t.Errorf("extractRepoName(%q) = %q, want %q", tt.fullName, result, tt.expected)
-			}
+var _ = Describe("Helper Functions", func() {
+	Describe("extractRepoName", func() {
+		It("should extract repo name from org/repo format", func() {
+			result := extractRepoName("konflux-ci/caching")
+			Expect(result).To(Equal("caching"))
 		})
-	}
-}
 
-func TestExtractReviewers(t *testing.T) {
-	tests := []struct {
-		name     string
-		owners   []string
-		expected []string
-	}{
-		{
-			name:     "mixed teams and users with @ prefix",
-			owners:   []string{"@konflux-ci/Vanguard", "@user1"},
-			expected: []string{"konflux-ci/Vanguard", "user1"},
-		},
-		{
-			name:     "empty list",
-			owners:   []string{},
-			expected: nil,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := extractReviewers(tt.owners)
-			if len(result) != len(tt.expected) {
-				t.Errorf("extractReviewers(%v) returned %d items, want %d", tt.owners, len(result), len(tt.expected))
-				return
-			}
-			for i := range result {
-				if result[i] != tt.expected[i] {
-					t.Errorf("extractReviewers(%v)[%d] = %q, want %q", tt.owners, i, result[i], tt.expected[i])
-				}
-			}
+		It("should return full name when no org prefix", func() {
+			result := extractRepoName("standalone-repo")
+			Expect(result).To(Equal("standalone-repo"))
 		})
-	}
-}
+	})
 
-func TestFormatList(t *testing.T) {
-	tests := []struct {
-		name      string
-		items     []string
-		emptyText string
-		expected  string
-	}{
-		{
-			name:      "multiple items",
-			items:     []string{"vendor/", "hack/"},
-			emptyText: "None",
-			expected:  "- `vendor/`\n- `hack/`",
-		},
-		{
-			name:      "empty list",
-			items:     []string{},
-			emptyText: "None",
-			expected:  "None",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := formatList(tt.items, tt.emptyText)
-			if result != tt.expected {
-				t.Errorf("formatList(%v, %q) = %q, want %q", tt.items, tt.emptyText, result, tt.expected)
-			}
+	Describe("extractReviewers", func() {
+		It("should extract reviewers from mixed teams and users with @ prefix", func() {
+			owners := []string{"@konflux-ci/Vanguard", "@user1"}
+			result := extractReviewers(owners)
+			Expect(result).To(Equal([]string{"konflux-ci/Vanguard", "user1"}))
 		})
-	}
-}
+
+		It("should return nil for empty list", func() {
+			owners := []string{}
+			result := extractReviewers(owners)
+			Expect(result).To(BeNil())
+		})
+	})
+
+	Describe("formatList", func() {
+		It("should format multiple items", func() {
+			items := []string{"vendor/", "hack/"}
+			result := formatList(items, "None")
+			Expect(result).To(Equal("- `vendor/`\n- `hack/`"))
+		})
+
+		It("should return emptyText for empty list", func() {
+			items := []string{}
+			result := formatList(items, "None")
+			Expect(result).To(Equal("None"))
+		})
+	})
+})

--- a/internal/pr/pr_suite_test.go
+++ b/internal/pr/pr_suite_test.go
@@ -1,0 +1,13 @@
+package pr
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestPr(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Pr Suite")
+}


### PR DESCRIPTION
### **User description**
- Add pr_suite_test.go to set up Ginkgo/Gomega test suite
- Convert creator_test.go from standard testing to Gomega

Assisted-by: Claude Code


___

### **PR Type**
Tests


___

### **Description**
- Convert `creator_test.go` from standard Go testing to Ginkgo/Gomega framework

- Add `pr_suite_test.go` to initialize Ginkgo test suite

- Replace table-driven tests with Ginkgo `Describe` and `It` blocks

- Use Gomega matchers (`Expect`, `Equal`, `BeNil`) for assertions


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Standard Go Testing"] -->|"Convert to Ginkgo/Gomega"| B["Ginkgo Test Suite"]
  C["creator_test.go<br/>Table-driven tests"] -->|"Refactor"| D["Describe/It blocks<br/>with Gomega matchers"]
  E["New pr_suite_test.go"] -->|"Initialize"| B
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>creator_test.go</strong><dd><code>Convert tests to Ginkgo/Gomega framework</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/pr/creator_test.go

<ul><li>Replaced standard Go <code>testing.T</code> imports with Ginkgo/Gomega imports<br> <li> Converted three test functions (<code>TestExtractRepoName</code>, <br><code>TestExtractReviewers</code>, <code>TestFormatList</code>) to Ginkgo <code>Describe</code> blocks<br> <li> Replaced table-driven test loops with individual <code>It</code> test cases<br> <li> Replaced manual error assertions with Gomega matchers (<code>Expect</code>, <code>Equal</code>, <br><code>BeNil</code>)</ul>


</details>


  </td>
  <td><a href="https://github.com/konflux-ci/coverage-dashboard/pull/14/files#diff-70e1b52dc1a0d8634909a93af556d6a23d72be3380ebefb4e56e5c1aaf418a19">+35/-85</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>pr_suite_test.go</strong><dd><code>Add Ginkgo test suite initialization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/pr/pr_suite_test.go

<ul><li>Created new Ginkgo test suite initialization file<br> <li> Imports Ginkgo/Gomega packages with dot notation<br> <li> Implements <code>TestPr</code> function that registers failure handler and runs <br>test specs</ul>


</details>


  </td>
  <td><a href="https://github.com/konflux-ci/coverage-dashboard/pull/14/files#diff-881cc991aa3d2774fef6ea9ae1abfd8542864dc79c66eef45020fdee8847542f">+13/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

