### PR TITLE
fix: Handle null coverage values in dashboard

### DIFF
--- a/index.html
+++ b/index.html
@@ -231,7 +231,7 @@
       const coverageDiv = cards.append("div");
 
       coverageDiv.html(d => {
-        if (isNaN(d.coverage)) return "N/A";
+        if (d.coverage === null || isNaN(d.coverage)) return "N/A";
 
         const cov = parseFloat(d.coverage).toFixed(1);
         let color = "red";
@@ -250,7 +250,9 @@
       d3.selectAll(".bar").transition()
         .duration(800)
         .style("width", function(_, i) {
-          const cov = data[i].coverage.toFixed(1);
+          const coverage = data[i].coverage;
+          if (coverage === null || isNaN(coverage)) return "0%";
+          const cov = parseFloat(coverage).toFixed(1);
           return cov + "%";
         });
 


### PR DESCRIPTION
### **User description**
Fix NaN% display for repositories with failed tests by explicitly checking for null coverage values before formatting.

Assisted-by: Claude Code


___

### **PR Type**
Bug fix


___

### **Description**
- Add null check for coverage values before formatting

- Prevent NaN% display in dashboard for failed tests

- Handle null coverage in bar animation calculations


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Coverage Data"] --> B["Null Check Added"]
  B --> C["Format Coverage Value"]
  C --> D["Display N/A or Percentage"]
  B --> E["Animate Bar Width"]
  E --> F["Show 0% or Calculated Width"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.html</strong><dd><code>Add null coverage checks to prevent NaN display</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

index.html

<ul><li>Added explicit null check before <code>isNaN()</code> validation in coverage <br>display logic<br> <li> Added null and NaN checks in bar animation width calculation<br> <li> Wrapped coverage value in <code>parseFloat()</code> for consistent type handling<br> <li> Returns "N/A" or "0%" when coverage is null or NaN</ul>


</details>


  </td>
  <td><a href="https://github.com/konflux-ci/coverage-dashboard/pull/15/files#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

