### PR TITLE
fix: grant GitHub App token organization-wide access

### DIFF
--- a/.github/workflows/discover-repos.yml
+++ b/.github/workflows/discover-repos.yml
@@ -40,6 +40,7 @@ jobs:
         with:
           app-id: ${{ secrets.GH_APP_ID }}
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          owner: konflux-ci
 
       - name: Run repository discovery
         env:


### PR DESCRIPTION
Add owner parameter to allow App token to access all repos in the konflux-ci organization for proper ownership detection.

Assisted-By: Claude Code