### PR TITLE
fix: exclude segment-bridge integration tests requiring containers

### DIFF
--- a/repos/segment-bridge.yaml
+++ b/repos/segment-bridge.yaml
@@ -12,6 +12,14 @@ exclude_dirs:
     - /mock(s)?(/|$)
     - /e2e(-tests)?(/|$)
     - docs/
+    - containerfixture/
+    - testfixture/
+    - webfixture/
+    - kwok/
+    - fetch-uj-records/
+    - uid_map/
+    - ws_map/
+    - splunk/
 exclude_files:
     - zz_generated.deepcopy.go
     - openapi_generated.go


### PR DESCRIPTION
### **User description**
The segment-bridge repository has integration tests that require Docker/Podman containers (specifically Splunk instances). These tests fail in the GitHub Actions environment because containers cannot be built or started.

Excluded packages:
- containerfixture/, testfixture/, webfixture/, kwok/ (test fixtures)
- fetch-uj-records/, uid_map/, ws_map/, splunk/ (integration tests)

This allows the coverage workflow to complete successfully while still tracking coverage for the main application code.

Assisted-by: Claude Code


___

### **PR Type**
Bug fix


___

### **Description**
- Exclude container-dependent test fixtures and integration tests

- Prevents GitHub Actions coverage workflow failures from missing Docker/Podman

- Maintains coverage tracking for main application code only


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["segment-bridge.yaml"] -- "adds 8 exclude patterns" --> B["Excludes test fixtures"]
  A -- "adds 8 exclude patterns" --> C["Excludes integration tests"]
  B -- "prevents failures" --> D["GitHub Actions coverage workflow"]
  C -- "prevents failures" --> D
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>segment-bridge.yaml</strong><dd><code>Add container-dependent test exclusions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

repos/segment-bridge.yaml

<ul><li>Added 8 new directory patterns to <code>exclude_dirs</code> configuration<br> <li> Excludes test fixture directories: <code>containerfixture/</code>, <code>testfixture/</code>, <br><code>webfixture/</code>, <code>kwok/</code><br> <li> Excludes integration test directories: <code>fetch-uj-records/</code>, <code>uid_map/</code>, <br><code>ws_map/</code>, <code>splunk/</code><br> <li> Prevents container-dependent tests from blocking coverage workflow in <br>GitHub Actions</ul>


</details>


  </td>
  <td><a href="https://github.com/konflux-ci/coverage-dashboard/pull/88/files#diff-cec650f62fc576f36f46292bee365d799505ed645195230f6d6191de1aad7e4c">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

