### PR TITLE
feat: run unit tests and upload to CodeCov

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,0 +1,36 @@
+name: Unit Tests and CodeCov
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    # Required for OIDC: https://github.com/codecov/codecov-action?tab=readme-ov-file#using-oidc
+    permissions:
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.23'
+
+      - name: Run tests with coverage
+        run: go test -v -coverprofile=coverage.out ./...
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          use_oidc: true
+          flags: unit-tests
+          files: coverage.out
+          fail_ci_if_error: false


### PR DESCRIPTION
https://issues.redhat.com/browse/COVERPORT-21

Before merging this PR, please add the repository upload token from here: https://app.codecov.io/github/konflux-ci/coverage-dashboard/config/general to the github actions secrets in this repo.