### PR TITLE
Add konflux-build-cli to the coverage dashboard

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -15,6 +15,11 @@
 /repos/project-controller.yaml @konflux-ci/Vanguard
 /repos/smee-sidecar.yaml @konflux-ci/Vanguard
 
+# Repositories with @konflux-ci/build-maintainers team ownership
+/repos/build-service.yaml @konflux-ci/build-maintainers
+/repos/image-controller.yaml @konflux-ci/build-maintainers
+/repos/konflux-build-cli.yaml @konflux-ci/build-maintainers
+
 # Repositories without CODEOWNERS - assigned to top contributors
 /repos/konflux-ci.yaml @yftacherzog
 /repos/notification-service.yaml @yftacherzog
@@ -40,11 +45,9 @@
 /repos/coverport.yaml @konflux-ci/qe
 /repos/devlake.yaml @konflux-ci/konflux-devprod-team
 /repos/operator-toolkit.yaml @konflux-ci/release-service-maintainers
-/repos/image-controller.yaml @konflux-ci/build-maintainers
 /repos/coverage-dashboard.yaml @konflux-ci/Vanguard
 /repos/application-api.yaml @konflux-ci/build-maintainers @konflux-ci/integration-service-maintainers
 /repos/integration-service.yaml @dirgim @hongweiliu17 @jsztuka @Josh-Everett @kasemAlem
-/repos/build-service.yaml @konflux-ci/build-maintainers
 /repos/workspace-manager.yaml @yftacherzog @gbenhaim @Omeramsc @avi-biton
 /repos/segment-bridge.yaml @Omeramsc
 

--- a/repos/konflux-build-cli.yaml
+++ b/repos/konflux-build-cli.yaml
@@ -1,0 +1,15 @@
+name: konflux-ci/konflux-build-cli
+exclude_dirs:
+    - .github/
+    - .tekton/
+    - cmd/ # command headers only
+    - docs/
+    - integration_tests/
+    - testutil/
+    - test/
+    - tests/
+    - vendor/
+exclude_files:
+    - main.go # one line entrypoint
+    - mock_*.go
+    - '*_mock.go'


### PR DESCRIPTION
Add [konflux-ci/konflux-build-cli](https://github.com/konflux-ci/konflux-build-cli) project to be included into the Coverage Dashboard.